### PR TITLE
Add  input `fullSize`  to config-element

### DIFF
--- a/src/app/components/landing-page/landing-page-dialog.component.html
+++ b/src/app/components/landing-page/landing-page-dialog.component.html
@@ -12,17 +12,17 @@
     <h2 mat-dialog-title>Set ALRAS Server url</h2>
     <mat-dialog-content>
         <div [formGroup]="this.mainFormService.getStartingGlobalForm()">
-            <app-config-element>
-                <div form-fields>
-                    <mat-form-field class="server-url-field">
+            <app-config-element [fullSize]="true">
+                <div form-fields class="server-url">
+                    <mat-form-field >
                         <mat-label>Server URL</mat-label>
                         <input matInput (change)="this.mainFormService.getStartingGlobalForm().get('serverUrl').valid ? checkUrl() : false" formControlName="serverUrl">
                     </mat-form-field>
                 </div>
             </app-config-element>
             <app-config-element *ngIf="isServerReady">
-                <div form-fields>
-                    <mat-form-field  class="collection-field">
+                <div form-fields class="collection">
+                    <mat-form-field >
                         <mat-label>Collections</mat-label>
                         <mat-select formControlName="collections" multiple>
                             <mat-option *ngFor="let collection of availablesCollections" value="{{collection}}">

--- a/src/app/components/landing-page/landing-page-dialog.component.scss
+++ b/src/app/components/landing-page/landing-page-dialog.component.scss
@@ -1,44 +1,48 @@
-$primary-color: #FF4081;
+$primary-color: #ff4081;
 
-.landing-container{
+.landing-container {
+  display: flex;
+  flex-direction: row;
+
+  .bloc {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    margin: 30px;
+    padding: 50px;
+    width: 150px;
+    background: $primary-color;
+    color: white;
+    font-weight: 200;
+    cursor: pointer;
+    font-size: 18px;
+    border-radius: 10px;
 
-    .bloc{
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        margin: 30px;
-        padding: 50px;
-        width: 150px;
-        background: $primary-color;
-        color: white;
-        font-weight: 200;
-        cursor: pointer;
-        font-size: 18px;
-        border-radius: 10px;
-
-        span{
-            text-align: center;
-        }
-
-        mat-icon{
-            font-size: 50px;
-            width: 50px;
-            height: 50px;
-        }
-
-        &:hover{
-            background: rgba($primary-color, 0.5);
-        }
+    span {
+      text-align: center;
     }
+
+    mat-icon {
+      font-size: 50px;
+      width: 50px;
+      height: 50px;
+    }
+
+    &:hover {
+      background: rgba($primary-color, 0.5);
+    }
+  }
 }
 
-.collection-field{
+.collection {
+  .mat-form-field {
     width: 100%;
+  }
 }
 
-.server-url-field{
+.server-url {
+  .mat-form-field {
     width: 100%;
+  }
 }

--- a/src/app/modules/map-config/components/layers/layers.component.scss
+++ b/src/app/modules/map-config/components/layers/layers.component.scss
@@ -1,7 +1,7 @@
 table {
-    width: 100%;
+  width: 100%;
 }
 
 button.add-layer {
-    margin: 16px 8px;
-  }
+  margin: 16px 8px;
+}

--- a/src/app/shared/components/config-element/config-element.component.html
+++ b/src/app/shared/components/config-element/config-element.component.html
@@ -1,7 +1,7 @@
 <div class="config-element">
 
     <div class="config-element-container">
-        <div class="form-fields">
+        <div class="form-fields" [class.full-size]="fullSize">
             <ng-content select="[form-fields]"></ng-content>
         </div>
         <div class="description">

--- a/src/app/shared/components/config-element/config-element.component.scss
+++ b/src/app/shared/components/config-element/config-element.component.scss
@@ -15,7 +15,6 @@
     .form-fields {
       min-width: 250px;
       padding: 10px;
-      flex: 1;
     }
 
     .description {
@@ -26,11 +25,15 @@
       line-height: 1.6;
       border-left: 0.2rem solid $config-element-description-border-color;
       background-color: $config-element-description-background;
-      border-radius: 4px;       
+      border-radius: 4px;
     }
 
     .description:not(:empty) {
       padding: 10px;
+    }
+
+    .full-size{
+      flex:1;
     }
   }
 }

--- a/src/app/shared/components/config-element/config-element.component.ts
+++ b/src/app/shared/components/config-element/config-element.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ContentChild } from '@angular/core';
+import { Component, OnInit, ContentChild, Input } from '@angular/core';
 import { FormControlName, FormGroupDirective } from '@angular/forms';
 
 @Component({
@@ -9,6 +9,7 @@ import { FormControlName, FormGroupDirective } from '@angular/forms';
 export class ConfigElementComponent implements OnInit {
 
   @ContentChild(FormControlName, { static: true }) formControl: FormControlName;
+  @Input() fullSize = false;
 
   constructor(public formGroupDirective: FormGroupDirective) { }
 


### PR DESCRIPTION
Allow a config element without description to take up all the space