### PR TITLE
Avoid 2 tabs to have the same name.

### DIFF
--- a/src/app/shared/components/input-modal/input-modal.component.html
+++ b/src/app/shared/components/input-modal/input-modal.component.html
@@ -1,10 +1,13 @@
 <div mat-dialog-content>
-    <h1 class="modal_title" mat-dialog-title>{{ 'Name' | translate }} </h1>
-    <mat-form-field>
-      <input matInput tabindex="1" [(ngModel)]="textName" (keypress)="pressEvent($event)">
-    </mat-form-field>
-  </div>
-  <div mat-dialog-actions>
-    <button mat-raised-button class="modal_button" color="primary" [mat-dialog-close]="textName" [disabled]="!textName" tabindex="2">{{ 'OK' | translate }}</button>
-    <button mat-raised-button class="modal_button" (click)="cancel()" tabindex="-1">{{ 'Cancel' | translate }}</button>
-  </div>
+  <h1 class="modal_title" mat-dialog-title>{{ data?.title || 'Name' | translate }} </h1>
+  <div>{{data?.message | translate}}</div>
+  <mat-form-field>
+    <input matInput tabindex="1" [(ngModel)]="textName" (keypress)="pressEvent($event)">
+  </mat-form-field>
+</div>
+<div mat-dialog-actions>
+  <button mat-raised-button class="modal_button" color="primary" [mat-dialog-close]="textName" [disabled]="!textName"
+    tabindex="2">{{ 'OK' | translate }}</button>
+  <button *ngIf="!data?.noCancel" mat-raised-button class="modal_button" (click)="cancel()"
+    tabindex="-1">{{ 'Cancel' | translate }}</button>
+</div>

--- a/src/app/shared/components/input-modal/input-modal.component.spec.ts
+++ b/src/app/shared/components/input-modal/input-modal.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { InputModalComponent } from './input-modal.component';
-import { MatDialogRef } from '@angular/material/dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { createComponentFactory, Spectator } from '@ngneat/spectator';
 
 describe('InputModalComponent', () => {
@@ -10,7 +10,10 @@ describe('InputModalComponent', () => {
   const createComponent = createComponentFactory({
     component: InputModalComponent,
     providers: [
-      { provide: MatDialogRef, useValue: {} }
+      {
+        provide: MatDialogRef, useValue: {}
+      },
+      { provide: MAT_DIALOG_DATA, useValue: {} },
     ]
   });
 

--- a/src/app/shared/components/input-modal/input-modal.component.ts
+++ b/src/app/shared/components/input-modal/input-modal.component.ts
@@ -16,8 +16,15 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 */
-import { Component } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+export interface DialogData {
+  title?: string;
+  message?: string;
+  initialValue?: string;
+  noCancel?: boolean;
+}
 
 @Component({
   selector: 'app-input-modal',
@@ -29,8 +36,15 @@ export class InputModalComponent {
   public textName: string;
 
   constructor(
-    public dialogRef: MatDialogRef<InputModalComponent>
-  ) { }
+    public dialogRef: MatDialogRef<InputModalComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: DialogData
+  ) {
+    this.textName = data.initialValue || '';
+
+    if (data && !!data.noCancel) {
+      dialogRef.disableClose = true;
+    }
+  }
 
   public cancel(): void {
     this.dialogRef.close();

--- a/src/app/utils/tools.ts
+++ b/src/app/utils/tools.ts
@@ -55,6 +55,27 @@ export function updateValueAndValidity(control: AbstractControl, onlySelf: boole
     }
 }
 
+/**
+ * Check that all sub-controls of a control have been touched.
+ * This is the case when we try to export => material touches all controls,
+ * so it can be detected to detect an export and display remaining errors.
+ */
+export function isFullyTouched(control: AbstractControl): boolean {
+
+    if (control instanceof FormControl) {
+        return control.touched;
+    } else if (control.touched && (control instanceof FormGroup || control instanceof FormArray)) {
+        if (control.controls.length === 0) {
+            return control.touched;
+        } else if (control.controls.length === 1) {
+            return Object.values(control.controls)[0].touched;
+        } else {
+            return Object.values(control.controls).map(c => isFullyTouched(c)).reduce((b1, b2) => b1 && b2);
+        }
+    }
+    return false;
+}
+
 export function getNbErrorsInControl(control: AbstractControl): number {
     let nbErrors = 0;
     nbErrors += !!control.errors ? Object.keys(control.errors).length : 0;


### PR DESCRIPTION
Display a dialog when saving a name that
is already used.
Also better detect tab errors.
Closes #128