### PR TITLE
Make ButtonToggler more intuitive

### DIFF
--- a/src/app/shared/models/config-form.ts
+++ b/src/app/shared/models/config-form.ts
@@ -248,7 +248,11 @@ export class ButtonToggleFormControl extends ConfigFormControl {
         optionalParams?: ControlOptionalParams
     ) {
 
-        super(formState, null, description, optionalParams);
+        super(
+            !!formState ? formState : !!options.length ? options[0].value : null,
+            null,
+            description,
+            optionalParams);
     }
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -117,7 +117,17 @@ body {
 
 #mapgl {
   width: 80% !important;
-  height: 80%!important;
-  margin: -24px!important;
+  height: 80% !important;
+  margin: -24px !important;
   position: absolute;
+}
+
+.mat-button-toggle-group {
+  mat-button-toggle.mat-button-toggle-checked {
+    background-color: white !important;
+  }
+  mat-button-toggle:not(.mat-button-toggle-checked) {
+    background-color: rgb(224, 224, 224) !important;
+    color: rgb(0, 0, 0, 0.25) !important;
+  }
 }


### PR DESCRIPTION
Change background color & text color.
Always set a default value, if none provided
(an element should be always choosen)