### PR TITLE
Fix palette édition

### DIFF
--- a/src/app/modules/map-config/components/dialog-palette-selector/dialog-palette-selector.component.ts
+++ b/src/app/modules/map-config/components/dialog-palette-selector/dialog-palette-selector.component.ts
@@ -90,13 +90,12 @@ export class DialogPaletteSelectorComponent implements OnInit {
     this.selectedPalette = this.defaultPalettes[index].slice();
   }
 
+  // reverse the colors but not the proportions
   public reverse() {
-    this.selectedPalette = this.selectedPalette.map((c: ProportionedValues) => {
-      return {
-        value: c.value,
-        proportion: 1 - c.proportion
-      };
-    }).reverse();
+    const proportions = this.selectedPalette.map(p => p.proportion);
+    const values = this.selectedPalette.map(p => p.value);
+    this.selectedPalette = values.reverse().map(
+      (value, index) => ({ proportion: proportions[index], value }));
   }
 
   public add(index: number) {

--- a/src/app/services/main-form-manager/config-map-export-helper.ts
+++ b/src/app/services/main-form-manager/config-map-export-helper.ts
@@ -117,10 +117,10 @@ export class ConfigMapExportHelper {
                 const interpolatedValues = fgValues.propertyInterpolatedFg;
                 let interpolatedColor: Array<string | Array<string | number>>;
                 const getField = () =>
-                    (mode === LAYER_MODE.features && interpolatedValues.propertyInterpolatedCountOrMetricCtrl === 'metric')
-                        ? interpolatedValues.propertyInterpolatedFieldCtrl :
-                        interpolatedValues.propertyInterpolatedFieldCtrl + '_' +
-                        (interpolatedValues.propertyInterpolatedMetricCtrl as string).toLowerCase() + '_';
+                    (interpolatedValues.propertyInterpolatedCountOrMetricCtrl === 'metric')
+                        ? interpolatedValues.propertyInterpolatedFieldCtrl + '_' +
+                        (interpolatedValues.propertyInterpolatedMetricCtrl as string).toLowerCase() + '_' :
+                        interpolatedValues.propertyInterpolatedFieldCtrl;
 
                 if (mode !== LAYER_MODE.features && interpolatedValues.propertyInterpolatedCountOrMetricCtrl === 'count') {
                     // for types FEATURE-METRIC and CLUSTER, if we interpolate by count

--- a/src/app/shared/services/property-selector-form-builder/property-selector-form-builder.service.ts
+++ b/src/app/shared/services/property-selector-form-builder/property-selector-form-builder.service.ts
@@ -484,7 +484,7 @@ export class PropertySelectorFormGroup extends ConfigFormGroup {
               isAggregated &&
               this.customControls.propertyInterpolatedFg.propertyInterpolatedCountOrMetricCtrl.value === COUNT_OR_METRIC.COUNT;
             const doNormalize =
-              !isAggregated && this.customControls.propertyInterpolatedFg.propertyInterpolatedNormalizeCtrl.value
+              !isAggregatedCount && this.customControls.propertyInterpolatedFg.propertyInterpolatedNormalizeCtrl.value
               || isAggregatedCount && !!this.customControls.propertyInterpolatedFg.propertyInterpolatedCountNormalizeCtrl.value;
             const isDensity = this.customControls.propertySource.value === PROPERTY_SELECTOR_SOURCE.heatmap_density;
 


### PR DESCRIPTION
Reverse fails in some cases.
With feature-metric and normalization,
palette values go from 0 to 0.