### PR TITLE
Fix mat-option width

### DIFF
--- a/src/app/modules/analytics-config/services/donut-form-builder/donut-form-builder.service.ts
+++ b/src/app/modules/analytics-config/services/donut-form-builder/donut-form-builder.service.ts
@@ -120,7 +120,7 @@ export class DonutConfigForm extends ConfigFormGroup {
                 || Array.from(this.customControls.dataStep.aggregationmodels.value).length === 0;
             }
           })
-      }).withTabName('Render'),
+      }).withTabName(marker('Render')),
       unmanagedFields: new FormGroup({
         renderStep: new FormGroup({
           customizedCssClass: new FormControl(),

--- a/src/app/modules/analytics-config/services/powerbar-form-builder/powerbar-form-builder.service.ts
+++ b/src/app/modules/analytics-config/services/powerbar-form-builder/powerbar-form-builder.service.ts
@@ -135,7 +135,7 @@ export class PowerbarConfigForm extends ConfigFormGroup {
           marker('Display the filter'),
           marker('powerbar display filter description')
         )
-      }).withTabName(marker('Data')),
+      }).withTabName(marker('Render')),
       unmanagedFields: new FormGroup({}) // for consistency with other widgets form builders
     });
   }

--- a/src/app/shared/components/config-form-control/config-form-control.component.html
+++ b/src/app/shared/components/config-form-control/config-form-control.component.html
@@ -33,7 +33,7 @@
             [dependants]="typedControl.resetDependantsOnChange && typedControl.dependantControls ? typedControl.dependantControls : null">
             <mat-option *ngIf="typedControl.optional"></mat-option>
             <mat-option *ngFor="let opt of typedControl.syncOptions" [value]="opt.value"
-                [ngClass]="'option-color-' + opt.value">
+                [ngClass]="'option-color-' + opt.value" [matTooltip]="opt.label | translate">
                 {{opt.label | translate}}
             </mat-option>
         </mat-select>
@@ -47,7 +47,7 @@
             [ngStyle]="{'backgroundImage': typedControl.value ? 'linear-gradient(to left, ' + typedControl.getCurrentOption().label + ')' : null}">
             <mat-option *ngIf="typedControl.optional"></mat-option>
             <mat-option *ngFor="let opt of typedControl.syncOptions" [value]="opt.value"
-                [ngStyle]="{'backgroundImage': 'linear-gradient(to left, ' + opt.label + ')'}">
+                [ngStyle]="{'backgroundImage': 'linear-gradient(to left, ' + opt.label + ')'}" [matTooltip]="opt.label | translate">
             </mat-option>
         </mat-select>
     </mat-form-field>
@@ -67,7 +67,7 @@
         </button>
         <mat-autocomplete autoActiveFirstOption #auto="matAutocomplete">
             <mat-option *ngIf="typedControl.optional"></mat-option>
-            <mat-option *ngFor="let opt of typedControl.filteredOptions" [value]="opt.value">
+            <mat-option *ngFor="let opt of typedControl.filteredOptions" [value]="opt.value" [matTooltip]="opt.label | translate">
                 {{opt.label | translate}}
             </mat-option>
         </mat-autocomplete>
@@ -81,7 +81,7 @@
             <mat-label>{{ typedControl.label | translate}}</mat-label>
             <mat-select #selectSort>
                 <mat-option *ngIf="typedControl.optional"></mat-option>
-                <mat-option *ngFor="let opt of typedControl.syncOptions" [value]="opt.value">
+                <mat-option *ngFor="let opt of typedControl.syncOptions" [value]="opt.value" [matTooltip]="opt.label | translate">
                     {{opt.label | translate}}
                 </mat-option>
             </mat-select>
@@ -123,7 +123,7 @@
                             [formControl]="typedControl.fieldCtrl">
 
                         <mat-autocomplete autoActiveFirstOption #auto="matAutocomplete">
-                            <mat-option *ngFor="let opt of typedControl.autocompleteFilteredFields" [value]="opt.value">
+                            <mat-option *ngFor="let opt of typedControl.autocompleteFilteredFields" [value]="opt.value" [matTooltip]="opt.label | translate">
                                 {{opt.label | translate}}
                             </mat-option>
                         </mat-autocomplete>
@@ -167,7 +167,7 @@
                             [formControl]="typedControl.fieldCtrl">
 
                         <mat-autocomplete autoActiveFirstOption #auto="matAutocomplete">
-                            <mat-option *ngFor="let opt of typedControl.autocompleteFilteredFields" [value]="opt.value">
+                            <mat-option *ngFor="let opt of typedControl.autocompleteFilteredFields" [value]="opt.value" [matTooltip]="opt.label | translate">
                                 {{opt.label | translate}}
                             </mat-option>
                         </mat-autocomplete>

--- a/src/app/shared/components/config-form-control/config-form-control.component.scss
+++ b/src/app/shared/components/config-form-control/config-form-control.component.scss
@@ -65,7 +65,7 @@ mat-option {
 
 .order-select-form-control {
     mat-form-field {
-        width: 180px;
+        width: fit-content;
         &.sort-list {
             width: 50%;
         }
@@ -128,7 +128,8 @@ mat-option {
 .color-preview-form-control {
     margin: 10px 0px;
     .color-preview {
-        width: 180px;
+        width: fit-content;
         height: 35px;
     }
 }
+

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -145,7 +145,3 @@ body {
     color: rgb(0, 0, 0, 0.25) !important;
   }
 }
-
-.cdk-overlay-pane {
-  width: unset !important;
-}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -145,3 +145,7 @@ body {
     color: rgb(0, 0, 0, 0.25) !important;
   }
 }
+
+.cdk-overlay-pane {
+  width: unset !important;
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26741864/91067004-ab01da00-e632-11ea-9e61-1e0c7a4f4961.png)


Allow us to see all the content of the options instead of '...'