### PR TITLE
Fix aggregation type in histogram & swimlane when choosing intervals

### DIFF
--- a/src/app/modules/analytics-config/services/analytics-import/analytics-import.service.ts
+++ b/src/app/modules/analytics-config/services/analytics-import/analytics-import.service.ts
@@ -176,7 +176,7 @@ export class AnalyticsImportService {
     const renderStep = widgetData.customControls.renderStep;
     const title = widgetData.customControls.title;
     const termeAggregationFg = dataStep.termAggregation;
-    const dateAggregationModel = contributor.swimlanes[0].aggregationmodels.find(m => m.type === 'datehistogram');
+    const dateAggregationModel = contributor.swimlanes[0].aggregationmodels.find(m => m.type === 'datehistogram' || m.type === 'histogram');
     const termAggregationModel = contributor.swimlanes[0].aggregationmodels.find(m => m.type === 'term');
     const swimlaneInput = component.input as AnalyticComponentSwimlaneInputConfig;
 
@@ -627,7 +627,6 @@ export class AnalyticsImportService {
     aggregationControls: BucketsIntervalControls,
     contribAggregationModel: AggregationModelConfig,
     dataType: string): Array<ImportElement> {
-
     return [{
       value: !contributor.numberOfBuckets ? BY_BUCKET_OR_INTERVAL.INTERVAL : BY_BUCKET_OR_INTERVAL.BUCKET,
       control: aggregationControls.aggregationBucketOrInterval

--- a/src/app/modules/analytics-config/services/swimlane-form-builder/swimlane-form-builder.service.ts
+++ b/src/app/modules/analytics-config/services/swimlane-form-builder/swimlane-form-builder.service.ts
@@ -34,12 +34,16 @@ import {
   MetricCollectFormBuilderService, MetricCollectFormGroup
 } from '../metric-collect-form-builder/metric-collect-form-builder.service';
 import { Observable } from 'rxjs';
-import { toKeywordOptionsObs, toDateFieldsObs } from '@services/collection-service/tools';
+import { toKeywordOptionsObs, toIntegerOrDateFieldsObs } from '@services/collection-service/tools';
 import { marker } from '@biesbjerg/ngx-translate-extract-marker';
 
 export enum SWIMLANE_REPRESENTATION {
   GLOBALLY = 'global',
   BY_COLUMN = 'column'
+}
+enum DateFormats {
+  English = '%b %d %Y  %H:%M',
+  French = '%d %b %Y  %H:%M'
 }
 export class SwimlaneFormGroup extends ConfigFormGroup {
 
@@ -119,6 +123,19 @@ export class SwimlaneFormGroup extends ConfigFormGroup {
               onDependencyChange: (control: HiddenFormControl) =>
                 control.setValue(!!this.customControls.renderStep.isZeroRepresentative.value ? defaultConfig.swimlaneZeroColor : null)
             }),
+          ticksDateFormat: new SelectFormControl(
+            '',
+            marker('Date format'),
+            marker('Date format description'),
+            false,
+            Object.keys(DateFormats).map(df => ({ value: DateFormats[df], label: df + '  (' + DateFormats[df] + ')' })),
+            {
+              optional: true,
+              dependsOn: () => [this.customControls.dataStep.aggregation],
+              onDependencyChange: (control) =>
+                control.enableIf(this.customControls.dataStep.aggregation.value.aggregationFieldType === 'time')
+            }
+          ),
           NaNColor: new HiddenFormControl(
             defaultConfig.swimlaneNanColor
           )
@@ -237,7 +254,7 @@ export class SwimlaneFormBuilderService extends WidgetFormBuilder {
 
     const formGroup = new SwimlaneFormGroup(
       this.bucketsIntervalBuilderService
-        .build(toDateFieldsObs(collectionFieldsObs), 'swimlane')
+        .build(toIntegerOrDateFieldsObs(collectionFieldsObs), 'swimlane')
         .withTitle(marker('swimlane x-axis')),
       this.metricBuilderService
         .build(collectionFieldsObs, 'swimlane')

--- a/src/app/services/collection-service/tools.ts
+++ b/src/app/services/collection-service/tools.ts
@@ -27,12 +27,12 @@ export const DATE_TYPES = [
     TypeEnum.DATE, TypeEnum.LONG
 ];
 
-export const INTEGER_TYPES = [
+export const INTEGER_OR_DATE_TYPES = [
     ...DATE_TYPES, TypeEnum.INTEGER
 ];
 
 export const NUMERIC_OR_DATE_TYPES = [
-    ...INTEGER_TYPES, TypeEnum.DOUBLE, TypeEnum.FLOAT
+    ...INTEGER_OR_DATE_TYPES, TypeEnum.DOUBLE, TypeEnum.FLOAT
 ];
 
 export const NUMERIC_OR_DATE_OR_TEXT_TYPES = [
@@ -56,6 +56,11 @@ export function toDateFieldsObs(collectionFieldsObs: Observable<Array<Collection
         fields => fields.filter(f => DATE_TYPES.indexOf(f.type) >= 0)));
 }
 
+export function toIntegerOrDateFieldsObs(collectionFieldsObs: Observable<Array<CollectionField>>) {
+    return collectionFieldsObs.pipe(map(
+        fields => fields.filter(f => INTEGER_OR_DATE_TYPES.indexOf(f.type) >= 0)));
+}
+
 export function toNumericOrDateOptionsObs(collectionFieldsObs: Observable<Array<CollectionField>>) {
     return toOptionsObs(toNumericOrDateFieldsObs(collectionFieldsObs));
 }
@@ -63,7 +68,7 @@ export function toNumericOrDateOptionsObs(collectionFieldsObs: Observable<Array<
 export function toIntegerOptionsObs(collectionFieldsObs: Observable<Array<CollectionField>>) {
     return toOptionsObs(collectionFieldsObs.pipe(map(
         fields => fields
-            .filter(f => INTEGER_TYPES.indexOf(f.type) >= 0))));
+            .filter(f => INTEGER_OR_DATE_TYPES.indexOf(f.type) >= 0))));
 }
 
 export function toKeywordOptionsObs(collectionFieldsObs: Observable<Array<CollectionField>>) {

--- a/src/app/services/main-form-manager/config-export-helper.ts
+++ b/src/app/services/main-form-manager/config-export-helper.ts
@@ -472,9 +472,8 @@ export class ConfigExportHelper {
             case WIDGET_TYPE.histogram: {
                 const contrib = this.getWidgetContributor(widgetData, widgetType, icon);
                 contrib.type = 'histogram';
-
                 const aggregationModel = {
-                    type: 'histogram',
+                    type: widgetData.dataStep.aggregation.aggregationFieldType === 'time' ? 'datehistogram' : 'histogram',
                     field: widgetData.dataStep.aggregation.aggregationField
                 } as AggregationModelConfig;
 
@@ -508,7 +507,7 @@ export class ConfigExportHelper {
                 });
 
                 const dateAggregationModel = {
-                    type: 'datehistogram',
+                    type: widgetData.dataStep.aggregation.aggregationFieldType === 'time' ? 'datehistogram' : 'histogram',
                     field: widgetData.dataStep.aggregation.aggregationField
                 } as AggregationModelConfig;
                 this.addNumberOfBucketsOrInterval(contrib, dateAggregationModel, widgetData.dataStep.aggregation);

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -139,7 +139,7 @@
 	"chart type description": "Choose the graphical rendering of the histogram buckets: \n • Area • Bars",
 	"Show horizontal lines?": "Show horizontal lines",
 	"Date format": "Date format",
-	"Date format description": "Choose the date format: \n • English: Month, dat, year \n • French: day, month, year",
+	"Date format description": "Choose the date format on the x-Axis: \n • English: Month, dat, year \n • French: day, month, year",
 	"metric title": "metric title",
 	"metric title description": "",
 	"Function": "Function",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -139,7 +139,7 @@
 	"chart type description": "Définit le rendu graphique des cases de l'histogramme: \n • Surface \n • Barres",
 	"Show horizontal lines?": "Afficher les lignes horizontales",
 	"Date format": "Format des dates",
-	"Date format description": "Format d'affichage des dates",
+	"Date format description": "Format d'affichage des dates sur l'axe des abscisses",
 	"metric title": "Titre de la métrique",
 	"metric title description": "",
 	"Function": "Fonction",


### PR DESCRIPTION
- Histograms are always considered as histogram aggregations whereas they can be datehistogram
- Allow interger types for swimlane aggregations