### PR TITLE
fix: remove useless scroll in edit widget popup

### DIFF
--- a/src/app/modules/analytics-config/components/edit-widget-dialog/edit-widget-dialog.component.scss
+++ b/src/app/modules/analytics-config/components/edit-widget-dialog/edit-widget-dialog.component.scss
@@ -20,3 +20,9 @@ under the License.
     display: flex;
     justify-content: space-evenly;
 }
+
+.mat-dialog-content {
+    ::ng-deep .mat-tab-body-content {
+        overflow: hidden;
+    }
+}


### PR DESCRIPTION
Fix #799