### PR TITLE
Disable reset of min/maxFieldValueCtrl

### DIFF
--- a/src/app/shared/services/property-selector-form-builder/property-selector-form-builder.service.ts
+++ b/src/app/shared/services/property-selector-form-builder/property-selector-form-builder.service.ts
@@ -585,7 +585,7 @@ export class PropertySelectorFormGroup extends CollectionConfigFormGroup {
             '',
             'number',
             {
-              resetDependantsOnChange: true,
+              resetDependantsOnChange: false,
               dependsOn: () => [
                 this.customControls.propertyInterpolatedFg.propertyInterpolatedNormalizeCtrl,
                 this.customControls.propertyInterpolatedFg.propertyInterpolatedFieldCtrl,
@@ -628,7 +628,7 @@ export class PropertySelectorFormGroup extends CollectionConfigFormGroup {
             '',
             'number',
             {
-              resetDependantsOnChange: true,
+              resetDependantsOnChange: false,
               dependsOn: () => [
                 this.customControls.propertyInterpolatedFg.propertyInterpolatedNormalizeCtrl,
                 this.customControls.propertyInterpolatedFg.propertyInterpolatedFieldCtrl,


### PR DESCRIPTION
- reseting the dependants of these 2 controls triggers a series of resets that end reseting the 'propertyInterpolatedValuesCtrl'
- Fix #783 