### PR TITLE
Fix spinner display in previews

### DIFF
--- a/src/app/modules/analytics-config/components/groups/groups.component.html
+++ b/src/app/modules/analytics-config/components/groups/groups.component.html
@@ -28,7 +28,7 @@
         </div>
 
         <div class="preview-group" *ngIf="groupsPreview.length > 0">
-            <arlas-analytics-board #analyticsBoard [groups]="groupsPreview" [showSpinner]="true"></arlas-analytics-board>
+            <arlas-analytics-board #analyticsBoard [groups]="groupsPreview" [showSpinner]="showSpinner" [diameterSpinner]="spinnerDiameter" [colorSpinner]="spinnerColor"></arlas-analytics-board>
         </div>
     </div>
 

--- a/src/app/modules/analytics-config/components/groups/groups.component.ts
+++ b/src/app/modules/analytics-config/components/groups/groups.component.ts
@@ -51,6 +51,10 @@ export class GroupsComponent implements OnInit, OnDestroy {
 
   private afterClosedSub: Subscription;
 
+  public spinnerColor: string;
+  public spinnerDiameter: number;
+  public showSpinner: boolean;
+
   public constructor(
     private defaultValuesService: DefaultValuesService,
     public dialog: MatDialog,
@@ -70,6 +74,9 @@ export class GroupsComponent implements OnInit, OnDestroy {
     this.updateDisplay.pipe(
       debounceTime(200)
     ).subscribe(() => this.updateAnalytics());
+    this.spinnerColor = this.mainFormService.lookAndFeelConfig?.control.value.LookAndFeelConfigGlobal.spinnerColor;
+    this.spinnerDiameter = this.mainFormService.lookAndFeelConfig?.control.value.LookAndFeelConfigGlobal.spinnerDiameter;
+    this.showSpinner = this.mainFormService.lookAndFeelConfig?.control.value.LookAndFeelConfigGlobal.spinner;
   }
 
   public addGroup() {

--- a/src/app/modules/look-and-feel-config/services/look-and-feel-global-form-builder/look-and-feel-global-form-builder.service.ts
+++ b/src/app/modules/look-and-feel-config/services/look-and-feel-global-form-builder/look-and-feel-global-form-builder.service.ts
@@ -103,9 +103,9 @@ export class LookAndFeelGlobalFormGroup extends ConfigFormGroup {
           '',
           marker('Spinner diameter'),
           null,
-          10,
-          100,
-          10,
+          20,
+          70,
+          5,
           null,
           null,
           {


### PR DESCRIPTION
Fix [issue#792](https://github.com/gisaia/ARLAS-wui-builder/issues/792)

The overflow was due to the spinner parameters of the preview coming from ARLAS-wui-toolkit. Also limited the size of the spinner to avoid overflowing when the values are high, and no spinner displaying with low values.