### PR TITLE
fix: initialisation of opacity settings

### DIFF
--- a/src/app/shared/services/property-selector-form-builder/property-selector-form-builder.service.ts
+++ b/src/app/shared/services/property-selector-form-builder/property-selector-form-builder.service.ts
@@ -455,7 +455,7 @@ export class PropertySelectorFormGroup extends CollectionConfigFormGroup {
             ],
             'Interpolated ' + propertyName + ' description',
             {
-              resetDependantsOnChange: true,
+              resetDependantsOnChange: false,
               dependsOn: () => [this.customControls.propertySource],
               onDependencyChange: (control) => control.enableIf(
                 this.customControls.propertySource.value !== PROPERTY_SELECTOR_SOURCE.heatmap_density && isAggregated)


### PR DESCRIPTION
Remove resetDependantOnChange from parent to avoid double init

Fix #797