### PR TITLE
Serve arlas-wui-builder on port 8080

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,6 @@ RUN rm -rf /usr/share/nginx/html/*
 COPY --from=builder /ng-app/dist/ARLAS-wui-builder /usr/share/nginx/html
 COPY --from=builder /ng-app/start.sh /usr/share/nginx/
 
-HEALTHCHECK CMD curl --fail http://localhost:80/ || exit 1
+HEALTHCHECK CMD curl --fail http://localhost:8080/ || exit 1
 
 CMD /usr/share/nginx/start.sh

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,6 +1,6 @@
 server {
 
-  listen 80;
+  listen 8080;
 
   sendfile on;
 


### PR DESCRIPTION
the 80 port is a privileged port that is not recommended by Sonarqube
- Fix #1045 